### PR TITLE
Fixes RT#90967  Class::MOP::load_class deprecation warning

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,7 @@ tests 't/*.t';
 
 requires 'POE'             => 0.12;
 requires 'Moose'           => 0.24;
+requires 'Class::Load'     => 0.20;
 requires 'Path::Class'     => 0;
 requires 'File::Signature' => 0;
 requires 'MooseX::Types::Path::Class' => 0;

--- a/lib/POE/Component/DirWatch.pm
+++ b/lib/POE/Component/DirWatch.pm
@@ -4,14 +4,14 @@ our $VERSION = "0.300001";
 
 use POE;
 use Moose;
-use Class::MOP;
+use Class::Load;
 use MooseX::Types::Path::Class qw/Dir/;
 
 sub import {
   my ($class, %args) = @_;
   return if delete $args{no_aio};
-  return unless eval { Class::MOP::load_class("POE::Component::AIO") };
-  if (eval { Class::MOP::load_class("POE::Component::DirWatch::Role::AIO") }){
+  return unless eval { Class::Load::load_class("POE::Component::AIO") };
+  if (eval { Class::Load::load_class("POE::Component::DirWatch::Role::AIO") }){
     $class->meta->make_mutable;
     POE::Component::DirWatch::Role::AIO->meta->apply($class->meta);
     $class->meta->make_immutable;


### PR DESCRIPTION
This fixes RT#90967: warnings produced by the deprecation of Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=90967
